### PR TITLE
Add support for schemaless mode making all integration tests pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REPORTER = spec
 DB?=waterline-test-integration
 
 test: clean-all test-unit test-integration-all
-test-all: test clean test-integration-documentdb
+test-all: test test-integration-schemaless clean test-integration-documentdb
 
 
 test-integration-all: test-integration-orientdb test-integration
@@ -18,7 +18,12 @@ test-integration: test-integration-generic
 	@NODE_ENV=test node test/integration/runner.js
 	
 test-integration-documentdb: test-integration-generic
+	@echo DATABASE_TYPE=document
 	@NODE_ENV=test DATABASE_TYPE=document node test/integration/runner.js
+	
+test-integration-schemaless: test-integration-generic
+	@echo SCHEMA=0
+	@NODE_ENV=test SCHEMA=0 node test/integration/runner.js
 
 test-integration-orientdb:
 	@echo "\n\nNOTICE: If tests fail, please ensure you've set the correct credentials in test/test-connection.json\n"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ var config = {
   },
   
   defaults: {
-    // The first time you run sails-orientdb `migrate` needs to be set to 'drop' or 'alter' in order to create the DB schema
+    // The first time you run sails-orientdb `migrate` needs to be set to 'drop', 'alter' or 'create' in order to create the DB schema
     // More about this on: http://sailsjs.org/#!/documentation/concepts/ORM/model-settings.html
     migrate: 'safe'
   }
@@ -95,6 +95,7 @@ var config = {
       user: 'root',
       password: 'root',
       database: 'waterline',
+      schema : true,
       
       // Additional options
       options: {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -92,7 +92,7 @@ module.exports = (function() {
       database : 'waterline',
       host : 'localhost',
       port : 2424,
-      // schema : false,  // to be consistent with OrientDB we should default to false but breaks 4 tests
+      schema : true,
       
       // Additional options
       options: {
@@ -297,7 +297,16 @@ module.exports = (function() {
     },
 
     update : function(connection, collection, options, values, cb) {
-      return connections[connection].update(collection, options, values, cb);
+      // TODO: On "1:1 update nested associations() when association have primary keys should update association values"
+      // test `values` includes an extraneous field `inspect`, this is a
+      // temporary workaround until we figure where `inspect` is coming from
+      if(values.inspect && typeof values.inspect === 'function') { delete values.inspect; }
+      
+      return connections[connection].update(collection, options, values, function(err, res){
+        if (err) { return cb(err); }
+        res.forEach(function(record){ utils.cleanOrientAttributes(record /*, TODO: add schema */); });
+        cb(null, res);
+      });
     },
 
     destroy : function(connection, collection, options, cb) {

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -27,6 +27,8 @@ if(process.argv.length > 2){
 var config = require('../test-connection.json');
 config.database = 'waterline-test-integration';  // We need different DB's due to https://github.com/orientechnologies/orientdb/issues/3301
 config.options.databaseType = argvDatabaseType || process.env.DATABASE_TYPE || config.options.databaseType || Adapter.defaults.options.databaseType;
+config.schema = process.env.SCHEMA !== undefined ? parseInt(process.env.SCHEMA) : Adapter.defaults.schema;
+
 
 // Grab targeted interfaces from this adapter's `package.json` file:
 var package = {};
@@ -49,6 +51,7 @@ log.info('Testing `' + package.name + '`, a Sails/Waterline adapter.');
 log.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
 log.info('( ' + interfaces.join(', ') + ' )');
 log.info('With database type: ' + config.options.databaseType);
+log.info('With schema:        ' + !!config.schema);
 console.log();
 log.info('Latest draft of Waterline adapter interface spec:');
 log.info('https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md');


### PR DESCRIPTION
Once balderdashy/waterline#959 is merged and waterline `0.10.22` is released all integration tests will pass in schemaless mode.