### PR TITLE
Wrong user/password for database(not server) credentials

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,7 +7,8 @@ var Oriento = require('oriento'),
     Associations = require('./associations'),
     log = require('debug-logger')('sails-orientdb:connection'),
     Collection = require('./collection'),
-    Sequel = require('waterline-sequel-orientdb');
+    Sequel = require('waterline-sequel-orientdb'),
+    Promise = require('bluebird');
 
 // waterline-sequel-orientdb options
 var sqlOptions = {
@@ -550,7 +551,7 @@ Connection.prototype._ensureDB = function _ensureDB (config) {
 
   if ( (!config.user) && (dbOptions.username) ) {
     // We only have database credentials; try to connect, assuming it exists.
-    return new Promise(function (resolve, reject) {
+    return new Promise(function (resolve) {
       resolve(self.server.use(dbOptions));
     });
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -548,6 +548,13 @@ Connection.prototype._ensureDB = function _ensureDB (config) {
   dbOptions.storage = config.options.storage;
   dbOptions.type = config.options.databaseType;
 
+  if ( (!config.user) && (dbOptions.username) ) {
+    // We only have database credentials; try to connect, assuming it exists.
+    return new Promise(function (resolve, reject) {
+      resolve(self.server.use(dbOptions));
+    });
+  }
+
   return self.server.list()
     .then(function(dbs) {
       var dbExists = _.find(dbs, function(db) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "async": "~0.9.0",
+    "bluebird": "^2.9.24",
     "debug-logger": "^0.4.0",
     "lodash": "^3.3.0",
     "oriento": "~1.1.0",

--- a/test/integration-orientdb/tests/config/database.test.js
+++ b/test/integration-orientdb/tests/config/database.test.js
@@ -4,7 +4,7 @@ var assert = require('assert'),
 var self = this,
     fixtures,
     config,
-		configConn = require('../../../test-connection.json');
+    configConn = require('../../../test-connection.json');
 
 describe('Config tests', function() {
   before(function (done) {
@@ -64,8 +64,6 @@ describe('Config tests', function() {
       ////////////////////////////////////////////////////
       it('should be the same as connection username', function(done) {
         CREATE_TEST_WATERLINE(self, config, fixtures, function(err){
-      		process.stdout.write("Data: " + JSON.stringify(config));
-      
           if(err) { return done(err); }
           self.collections.User.getDB(function(db){
             assert.equal(db.username, config.user);
@@ -95,23 +93,23 @@ describe('Config tests', function() {
         });
       });
 
-			it('should be able to connect with database credentials only', function(done) {
-				self.waterline.teardown(function (err) {
-					if (err) { return done(err); }
-					
-					var newConfig = _.cloneDeep(configConn);
-					newConfig.user = undefined;
-					newConfig.password = undefined;
-					newConfig.options.databaseUser = newConfig.databaseTestUser;
-					newConfig.options.databasePassword = newConfig.databaseTestPassword;
-
+      it('should be able to connect with database credentials only', function(done) {
+        self.waterline.teardown(function (err) {
+          if (err) { return done(err); }
+          
+          var newConfig = _.cloneDeep(configConn);
+          newConfig.user = undefined;
+          newConfig.password = undefined;
+          newConfig.options.databaseUser = newConfig.databaseTestUser || 'admin';
+          newConfig.options.databasePassword = newConfig.databaseTestPassword || 'admin';
+          
           CREATE_TEST_WATERLINE(self, newConfig, fixtures, function(err){
             if (err) { return done(err); }
-						
-						done();
-					});
-				});
-			})      
+            
+            done();
+          });
+        });
+      })      
     });
   });
 });

--- a/test/integration-orientdb/tests/config/database.test.js
+++ b/test/integration-orientdb/tests/config/database.test.js
@@ -3,7 +3,8 @@ var assert = require('assert'),
 
 var self = this,
     fixtures,
-    config;
+    config,
+		configConn = require('../../../test-connection.json');
 
 describe('Config tests', function() {
   before(function (done) {
@@ -25,8 +26,8 @@ describe('Config tests', function() {
     };
     
     config = {
-      user : 'root',
-      password : 'root',
+      user : configConn.user,
+      password : configConn.password,
       database : 'test_config_db'
     };
 
@@ -61,12 +62,13 @@ describe('Config tests', function() {
       /////////////////////////////////////////////////////
       // TEST METHODS
       ////////////////////////////////////////////////////
-      
       it('should be the same as connection username', function(done) {
         CREATE_TEST_WATERLINE(self, config, fixtures, function(err){
+      		process.stdout.write("Data: " + JSON.stringify(config));
+      
           if(err) { return done(err); }
           self.collections.User.getDB(function(db){
-            assert.equal(db.username, 'root');
+            assert.equal(db.username, config.user);
             done();
           });
         });
@@ -92,7 +94,24 @@ describe('Config tests', function() {
           });
         });
       });
-      
+
+			it('should be able to connect with database credentials only', function(done) {
+				self.waterline.teardown(function (err) {
+					if (err) { return done(err); }
+					
+					var newConfig = _.cloneDeep(configConn);
+					newConfig.user = undefined;
+					newConfig.password = undefined;
+					newConfig.options.databaseUser = newConfig.databaseTestUser;
+					newConfig.options.databasePassword = newConfig.databaseTestPassword;
+
+          CREATE_TEST_WATERLINE(self, newConfig, fixtures, function(err){
+            if (err) { return done(err); }
+						
+						done();
+					});
+				});
+			})      
     });
   });
 });


### PR DESCRIPTION
Currently, we require to insert server (root) credentials.
This is since in connection.js, we try to get list of databases, and if one doesn't exists, we attempt to create it.

I added an option we can bypass that, and only enter database credentials rather than server credentials. Obviously, however, one has to create the database in advance.

To use it, simply omit config.username , and use config.options.databaseUser
Note the code only checks for the username, but the password should accompany the user in the same location.