### PR TITLE
92: Connection pooling

### DIFF
--- a/.settings/launch.json
+++ b/.settings/launch.json
@@ -25,7 +25,6 @@
 			"name": "Unit tests",
 			"type": "node",
 			"program": ".settings/mocha.js",
-			"isTestCommand": true,
 			"stopOnEntry": true,
 			"args": ["test/unit/*.js", "test/unit/**/*.js"],
 			"cwd": ".",
@@ -36,7 +35,6 @@
 			"name": "OrientDB Integration tests",
 			"type": "node",
 			"program": ".settings/mocha.js",
-			"isTestCommand": true,
 			"stopOnEntry": true,
 			"args": [
 				"test/integration-orientdb/*.js", 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-integration-orientdb:
 	@echo "Running waterline-orientdb integration tests..."
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
-		--timeout 6000 --globals Associations,CREATE_TEST_WATERLINE,DELETE_TEST_WATERLINE \
+		--timeout 8000 --globals Associations,CREATE_TEST_WATERLINE,DELETE_TEST_WATERLINE \
 		test/integration-orientdb/*.js test/integration-orientdb/tests/**/*.js \
 		test/integration-orientdb/bugs/*.js test/integration-orientdb/bugs/**/*.js
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-integration-orientdb:
 	@echo "Running waterline-orientdb integration tests..."
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
-		--timeout 8000 --globals Associations,CREATE_TEST_WATERLINE,DELETE_TEST_WATERLINE \
+		--timeout 6000 --globals Associations,CREATE_TEST_WATERLINE,DELETE_TEST_WATERLINE \
 		test/integration-orientdb/*.js test/integration-orientdb/tests/**/*.js \
 		test/integration-orientdb/bugs/*.js test/integration-orientdb/bugs/**/*.js
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -108,6 +108,10 @@ module.exports = (function() {
         // transport: binary | rest. Currently only binary is supported: https://github.com/codemix/oriento/issues/44
         transport : 'binary',
         //
+        // connection pool: by default oriento uses one socket per server, but it is also possible to use a connection 
+        // pool by adding a pool object that will be sent to Oriento, e.g.: { max: 10 }
+        pool: null,
+        //
         // Sets the oriento logger for error, log and debug. e.g.: { debug: console.log.bind(console) }
         orientoLogger : {},
         //

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -529,6 +529,10 @@ Connection.prototype._getOriento = function _getOriento(config) {
     logger : config.options.orientoLogger
   };
   
+  if(config.options.pool){
+    orientoOptions.pool = config.options.pool;
+  }
+  
   return new Oriento(orientoOptions);
 };
 

--- a/test/integration-orientdb/tests/config/options.test..js
+++ b/test/integration-orientdb/tests/config/options.test..js
@@ -27,7 +27,7 @@ describe('Config tests', function() {
     config = {
       user : 'root',
       password : 'root',
-      database : 'test_config_db'
+      database: 'test_config_options_db'
     };
 
     CREATE_TEST_WATERLINE(self, config, fixtures, done);
@@ -36,9 +36,9 @@ describe('Config tests', function() {
     DELETE_TEST_WATERLINE(config, done);
   });
 
-  describe('database', function() {
+  describe('options', function() {
   
-    describe('username', function() {
+    describe('pool', function() {
 
     /////////////////////////////////////////////////////
     // TEST SETUP
@@ -62,33 +62,30 @@ describe('Config tests', function() {
       // TEST METHODS
       ////////////////////////////////////////////////////
       
-      it('should be the same as connection username', function (done) {
+      it('should be undefined', function (done) {
         CREATE_TEST_WATERLINE(self, config, fixtures, function (err) {
           if (err) {  return done(err); }
-          self.collections.User.getDB(function (db) {
-            assert.equal(db.username, 'root');
-            done();
-          });
+          var server = self.collections.User.getServer();
+          assert.equal(server.transport.pool, undefined);
+          done();
         });
       });
       
-      it('should be the same as databaseUser', function (done) {
+      it('should have max equal 10', function (done) {
         self.waterline.teardown(function (err) {
           if (err) {  return done(err); }
 
           var newConfig = _.cloneDeep(config);
 
           newConfig.options = {
-            databaseUser: 'admin',
-            databasePassword: 'admin',
+            pool: { max: 10 }
           };
 
           CREATE_TEST_WATERLINE(self, newConfig, fixtures, function (err) {
             if (err) {  return done(err); }
-            self.collections.User.getDB(function (db) {
-              assert.equal(db.username, 'admin');
-              done();
-            });
+            var server = self.collections.User.getServer();
+            assert.equal(server.transport.pool.max, 10);
+            done();
           });
         });
       });

--- a/test/integration-orientdb/tests/config/options.test..js
+++ b/test/integration-orientdb/tests/config/options.test..js
@@ -72,6 +72,7 @@ describe('Config tests', function() {
       });
       
       it('should have max equal 10', function (done) {
+        this.timeout(25000);  // this takes more than 6000ms on travis
         self.waterline.teardown(function (err) {
           if (err) {  return done(err); }
 

--- a/test/integration-orientdb/tests/config/options.test..js
+++ b/test/integration-orientdb/tests/config/options.test..js
@@ -71,7 +71,7 @@ describe('Config tests', function() {
         });
       });
       
-      it('should have max equal 10', function (done) {
+      it('should have max equal 2', function (done) {
         this.timeout(25000);  // this takes more than 6000ms on travis
         self.waterline.teardown(function (err) {
           if (err) {  return done(err); }
@@ -85,7 +85,7 @@ describe('Config tests', function() {
           CREATE_TEST_WATERLINE(self, newConfig, fixtures, function (err) {
             if (err) {  return done(err); }
             var server = self.collections.User.getServer();
-            assert.equal(server.transport.pool.max, 10);
+            assert.equal(server.transport.pool.max, 2);
             done();
           });
         });


### PR DESCRIPTION
Allows configuring Oriento's connection pool through the config, example:

```js
  connections: {
    myLocalOrient: {
      //...
      pool: { max: 10 }
    }
  }
```

#### Caveat
back in https://github.com/codemix/oriento/commit/a754c48b824f159b8a2e7ba9c5767b3b0b54b1e6 connection pool config was removed from Oriento's README.md with the message:
> remove mention of connection pooling until issues with thread safety are fixed in orientdb

Currently we don't know the status of this, so use at your own risk.

Fixes #92.