### PR TITLE
travis: Update OrientDB to 2.0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - DEBUG="sails-orientdb:*,-sails-orientdb:*:debug"
   matrix:
     - ORIENTDB_VERSION=1.7.10
-    - ORIENTDB_VERSION=2.0.8
+    - ORIENTDB_VERSION=2.0.9
 addons:
   code_climate:
     repo_token: 9048159e3344dd9ba3afbc6044c1648f472de839baf7cc9eb73089b71439052b


### PR DESCRIPTION
Update OrientDB to 2.0.9 (latest available at http://mvnrepository.com/artifact/com.orientechnologies/orientdb-community)