### PR TITLE
Make matchRecordId() quicker

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,10 +146,9 @@ exports.rewriteIdsRecursive = function rewriteIdsRecursive(models, schema, accum
  * @api public
  */
 exports.matchRecordId = function matchRecordId(id) {
-  if (id === null) return false;
-  var test = _.cloneDeep(id);
-  if(typeof test.toString !== 'undefined')
-    test = id.toString();
+  if (!id) return false;
+  if(id instanceof RecordId) { return true; }
+  var test = id.toString();
   return test.match(/^\#\-?\d+\:\d+$/) ? true : false;
 };
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -2,7 +2,8 @@
  * Test dependencies
  */
 var assert = require('assert'),
-    utils = require('../../lib/utils');
+    utils = require('../../lib/utils'),
+    RecordId = require('oriento').RID;
 
 
 describe('utils helper class', function () {
@@ -256,4 +257,45 @@ describe('utils helper class', function () {
       done();
     });
   });
+  
+  describe('matchRecordId:', function () {
+    
+    var fixturesTrue = [
+      new RecordId('#10:1'),
+      new RecordId('#0:0'),
+      new RecordId('#-2:1'),
+      '#5:5',
+      '#5:0',
+      '#-2:0',
+      '#-2:1'
+    ];
+    
+    var fixturesFalse = [
+      null,
+      undefined,
+      4,
+      '5',
+      '5:5',
+      '-2:1',
+      '#5',
+      '#5:5:5',
+      '#2:-1',
+      '#:1'
+    ];
+    
+    it('should match genuine Record IDs', function () {
+      fixturesTrue.forEach(function(rid){
+        assert.equal(utils.matchRecordId(rid), true, 'test failed for: ' + rid);
+      });
+    });
+    
+    it('should not match invalid Record IDs', function () {
+      fixturesFalse.forEach(function(rid){
+        assert.equal(utils.matchRecordId(rid), false, 'test failed for: ' + rid);
+      });
+    });
+  });
+  
+  
+  
 });


### PR DESCRIPTION
This improves matchRecordId() speed by 2.5x:
https://gist.github.com/dmarcelino/5dc29b529183d9e38a54