### PR TITLE
Fix build (by manipulating dependencies' versions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,13 @@ clean:
 	@echo "\n\nDROPPING ALL COLLECTIONS from db: $(DB)"
 	@echo "NOTICE: If operation fails, please ensure you've set the correct credentials in orientjs.opts file"
 	@echo "Note: you can choose which db to drop by appending 'DB=<db_name>', e.g. 'make clean DB=waterline-test-orientdb'\n"
-	./node_modules/.bin/oriento db drop $(DB) || true
+	./node_modules/.bin/orientjs db drop $(DB) || true
 	
 clean-all:
 	@echo "\n\nDROPPING DATABASES: waterline-test-integration, waterline-test-orientdb"
 	@echo "NOTICE: If operation fails, please ensure you've set the correct credentials in orientjs.opts file\n"
-	./node_modules/.bin/oriento db drop waterline-test-integration > /dev/null 2>&1 || true
-	./node_modules/.bin/oriento db drop waterline-test-orientdb > /dev/null 2>&1 || true
+	./node_modules/.bin/orientjs db drop waterline-test-integration > /dev/null 2>&1 || true
+	./node_modules/.bin/orientjs db drop waterline-test-orientdb > /dev/null 2>&1 || true
 	@echo "Done"
 
 .PHONY: coverage

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "istanbul": "^0.3.5",
     "jshint": "*",
     "mocha": "*",
-    "waterline": "~0.10.18",
+    "waterline-schema": "0.1.18",
+    "waterline": "0.10.27",
     "waterline-adapter-tests": "0.10.11"
   },
   "waterlineAdapter": {


### PR DESCRIPTION
Adding waterline-schema dep (hack) and limiting waterline to 0.10.27
waterline-schema is not a direct dependency for sails-orientdb (it's a dependency for waterline) but 0.10.19 breaks the tests so we are keeping it at v0.10.18 so the tests run. This is a temporary solution until the necessary code changes are made.

Additionally fixed the Makefile